### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ acce.on('identify', function(paired, callback) {
 });
 
 acce
-.addService(Service.Lightbulb, 'Yeelight')
-.getCharacteristic(Characteristic.On)
+.addService(HomeKit.Service.Lightbulb, 'Yeelight')
+.getCharacteristic(HomeKit.Characteristic.On)
 .on('set', function(value, callback) {
   light.set_power(value, callback);
 })


### PR DESCRIPTION
The current example in the README.md won't run because the `Service` and `Characteristic` objects are only available under the `HomeKit` object. This fixes the example.